### PR TITLE
Add type to HTTP method and status enum

### DIFF
--- a/src/server/common/index.ts
+++ b/src/server/common/index.ts
@@ -1,0 +1,13 @@
+export enum Status {
+  // Accepted status
+  OK = 200,
+
+  // Client-error status
+  BAD_REQUEST = 400,
+  UNAUTHORIZED = 401,
+  NOT_FOUND = 404,
+
+  // Server-error status
+  INTERNAL_SERVER_ERROR = 500,
+  NOT_IMPLEMENTED = 501,
+}

--- a/src/types/fetch.d.ts
+++ b/src/types/fetch.d.ts
@@ -1,0 +1,11 @@
+/**
+ * Extends fetch input parameters.
+ */
+interface ExtendedRequestInit extends RequestInit {
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+}
+
+declare function fetch(
+  input: URL | RequestInfo,
+  init?: ExtendedRequestInit
+): Promise<Response>;


### PR DESCRIPTION
# Description

Add "quality-of-life" enhancement to `fetch` request and response.

1. HTTP request methods are constrained to `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`. These methods aligned with [Next.js route handlers specifications](https://nextjs.org/docs/app/building-your-application/routing/route-handlers#supported-http-methods). Typescript can now provide us type hints
  
   ![image](https://github.com/JumboCode/TheLegacyProject2/assets/74647679/d9ce78db-01a0-494d-ba59-7efb0a1f34bf)

2. Add a enum for common status code that I anticipated would be useful for our development. The idea is that it's easier to understand the intent of the status code from the enums, instead of trying to remember what all the numbers represent.

## Possible Downsides

The type-hint for HTTP request methods doesn't raise a compilation error with typo - i.e someone can still type a bogus HTTP method.