### PR TITLE
Refactor API edit-profile endpoint and implement edit role

### DIFF
--- a/src/app/api/resources/route.schema.ts
+++ b/src/app/api/resources/route.schema.ts
@@ -1,7 +1,6 @@
 import { Prisma } from "@prisma/client";
+import { roleSchema } from "@server/schema";
 import z from "zod";
-
-const roleSchema = z.enum(["USER", "CHAPTER_LEADER", "ADMIN"]);
 
 /**
  * TODO - What should the maximum length of title be?

--- a/src/app/api/user/[uid]/edit-profile/route.ts
+++ b/src/app/api/user/[uid]/edit-profile/route.ts
@@ -1,112 +1,59 @@
-import { NextRequest, NextResponse } from "next/server";
-import { EditProfileRequest, EditPositionRequest } from "./route.schema";
+import { NextResponse } from "next/server";
+import { EditProfileRequest } from "./route.schema";
 import { EditProfileResponse } from "./route.schema";
 import { prisma } from "@server/db/client";
 import { withSession } from "@server/decorator";
 
-/* PATCH Request for updating profile information */
-export const PATCH = async (
-  request: NextRequest,
-  { params }: { params: { uid: string } }
-) => {
-  const makePatch = withSession(async ({ session, req, params }) => {
-    try {
-      const targetUID: string = params.uid;
-      const target = await prisma.user.findUnique({
-        where: {
-          id: targetUID,
-        },
-      });
-      if (!target) {
-        return NextResponse.json(
-          EditProfileResponse.parse({
-            code: "INVALID_UID",
-            message: "Could not find user with the given UID",
-          }),
-          { status: 400 }
-        );
-      }
-
-      const can_edit_self = session.user.id === target.id;
-      /** @todo check if Chapter Leader is editing a User in the same Chapter */
-      const can_update_position =
-        (session.user.role === "ADMIN" && target.role !== "ADMIN") ||
-        (session.user.role === "CHAPTER_LEADER" && target.role === "USER");
-
-      if (can_edit_self) {
-        const editRequest = EditProfileRequest.safeParse(await req.json());
-        if (!editRequest.success) {
-          return NextResponse.json(
-            EditProfileResponse.parse({
-              code: "INVALID_FORM",
-              message: "Invalid form submission",
-            }),
-            { status: 400 }
-          );
-        }
-        const body = editRequest.data;
-        await prisma.user.update({
-          where: {
-            id: targetUID,
-          },
-          data: {
-            firstName: body.firstName,
-            lastName: body.lastName,
-            pronouns: body.pronouns,
-          },
-        });
-        return NextResponse.json(
-          EditProfileResponse.parse({
-            code: "SUCCESS",
-            message: "Profile successfully updated",
-          }),
-          { status: 200 }
-        );
-      } else if (can_update_position) {
-        const editRequest = EditPositionRequest.safeParse(await req.json());
-        if (!editRequest.success) {
-          return NextResponse.json(
-            EditProfileResponse.parse({
-              code: "INVALID_FORM",
-              message: "Invalid form submission",
-            }),
-            { status: 400 }
-          );
-        }
-        const body = editRequest.data;
-        await prisma.user.update({
-          where: {
-            id: targetUID,
-          },
-          data: {
-            position: body.position,
-          },
-        });
-        return NextResponse.json(
-          EditProfileResponse.parse({
-            code: "SUCCESS",
-            message: "Profile successfully updated",
-          }),
-          { status: 200 }
-        );
-      } else {
-        return NextResponse.json(
-          EditProfileResponse.parse({
-            code: "UNAUTHORIZED",
-            message: "The action cannot be performed by the current user",
-          }),
-          { status: 401 }
-        );
-      }
-    } catch {
+/*
+ * Update user profile information.
+ */
+export const PATCH = withSession(async ({ session, req, params }) => {
+  try {
+    if (params.params.uid !== session.user.id) {
       return NextResponse.json(
         EditProfileResponse.parse({
-          code: "UNKNOWN",
-          message: "Unknown error received",
+          code: "UNAUTHORIZED",
+          message: "The action cannot be performed by the current user"
         }),
-        { status: 500 }
+        { status: 400 }
       );
     }
-  });
-  return makePatch(request, params);
-};
+
+    const editRequest = EditProfileRequest.safeParse(await req.json());
+    if (!editRequest.success) {
+      return NextResponse.json(
+        EditProfileResponse.parse({
+          code: "INVALID_FORM",
+          message: "Invalid form submission",
+        }),
+        { status: 400 }
+      );
+    }
+    const body = editRequest.data;
+    await prisma.user.update({
+      where: {
+        id: session.user.id,
+      },
+      data: {
+        firstName: body.firstName,
+        lastName: body.lastName,
+        pronouns: body.pronouns,
+      },
+    });
+    return NextResponse.json(
+      EditProfileResponse.parse({
+        code: "SUCCESS",
+        message: "Profile successfully updated",
+      }),
+      { status: 200 }
+    );
+  } catch {
+    return NextResponse.json(
+      EditProfileResponse.parse({
+        code: "UNKNOWN",
+        message: "Unknown error received",
+      }),
+      { status: 500 }
+    );
+  }
+});

--- a/src/app/api/user/[uid]/edit-role/route.client.ts
+++ b/src/app/api/user/[uid]/edit-role/route.client.ts
@@ -1,0 +1,16 @@
+import { TypedRequest } from "@server/type";
+import { z } from "zod";
+import { EditRoleRequest, EditRoleResponse } from "./route.schema";
+
+export const editRole = async (
+  request: TypedRequest<z.infer<typeof EditRoleRequest>>,
+  uid: string
+) => {
+  const { body, ...options } = request;
+  const response = await fetch(`/api/user/${uid}/edit-role`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+    ...options,
+  });
+  return EditRoleResponse.parse(await response.json());
+};

--- a/src/app/api/user/[uid]/edit-role/route.schema.ts
+++ b/src/app/api/user/[uid]/edit-role/route.schema.ts
@@ -1,0 +1,24 @@
+import { roleSchema } from "@server/schema";
+import { z } from "zod";
+
+export const EditRoleRequest = z.object({
+  role: roleSchema.refine(
+    (value): value is "CHAPTER_LEADER" | "USER" =>
+      value === "CHAPTER_LEADER" || value === "USER"
+  ),
+});
+
+export const EditRoleResponse = z.discriminatedUnion("code", [
+  z.object({
+    code: z.literal("SUCCESS"),
+    message: z.string(),
+  }),
+  z.object({
+    code: z.literal("INVALID_REQUEST"),
+    message: z.string(),
+  }),
+  z.object({
+    code: z.literal("UNKNOWN"),
+    message: z.string(),
+  }),
+]);

--- a/src/app/api/user/[uid]/edit-role/route.ts
+++ b/src/app/api/user/[uid]/edit-role/route.ts
@@ -1,0 +1,50 @@
+import { withRole, withSession } from "@server/decorator";
+import { EditRoleRequest, EditRoleResponse } from "./route.schema";
+import { NextResponse } from "next/server";
+import { prisma } from "@server/db/client";
+
+/**
+ * Update a non-admin user's role.
+ */
+export const PATCH = withSession(
+  withRole(["ADMIN"], async ({ req, params }) => {
+    const { uid } = params.params;
+    const maybeBody = EditRoleRequest.safeParse(await req.json());
+    const maybeUser = await prisma.user.findUnique({ where: { id: uid } });
+
+    if (!maybeBody.success || maybeUser == null || maybeUser.role === "ADMIN") {
+      return NextResponse.json(
+        EditRoleResponse.parse({
+          code: "INVALID_REQUEST",
+          message: "Invalid request",
+        }),
+        { status: 400 }
+      );
+    }
+
+    try {
+      await prisma.user.update({
+        where: {
+          id: uid,
+        },
+        data: {
+          role: maybeBody.data.role,
+        },
+      });
+
+      return NextResponse.json(
+        EditRoleResponse.parse({
+          code: "SUCCESS",
+          message: "Updated user role",
+        })
+      );
+    } catch (e) {
+      return NextResponse.json(
+        EditRoleResponse.parse({
+          code: "UNKNOWN",
+          message: "Unknown error occurred",
+        })
+      );
+    }
+  })
+);

--- a/src/server/decorator/index.ts
+++ b/src/server/decorator/index.ts
@@ -6,10 +6,8 @@ import { unauthorizedErrorResponse } from "@api/route.schema";
 
 /**
  * NextApiParams is of type dictionary when an endpoint with dynamic url is hit.
- *
- * @todo Rewrite type of params - kinda janky
  */
-type NextApiParams = any;
+type NextApiParams = { params: Record<string, string> };
 
 interface AuthorizedSession extends Session {
   user: NonNullable<Session["user"]>;
@@ -81,5 +79,4 @@ const withRole = (
   };
 };
 
-export { withSession, withRole };
-export { withSessionAndRole };
+export { withSession, withRole, withSessionAndRole };

--- a/src/server/decorator/index.ts
+++ b/src/server/decorator/index.ts
@@ -6,8 +6,9 @@ import { unauthorizedErrorResponse } from "@api/route.schema";
 
 /**
  * NextApiParams is of type dictionary when an endpoint with dynamic url is hit.
+ * @todo Rewrite type of params - kinda janky
  */
-type NextApiParams = { params: Record<string, string> };
+type NextApiParams = any;
 
 interface AuthorizedSession extends Session {
   user: NonNullable<Session["user"]>;

--- a/src/server/schema/index.ts
+++ b/src/server/schema/index.ts
@@ -1,0 +1,8 @@
+import { Role } from "@prisma/client";
+import { z } from "zod";
+
+export const roleSchema = z.enum([
+  "USER",
+  "CHAPTER_LEADER",
+  "ADMIN",
+]) satisfies z.ZodType<Role>;

--- a/src/server/type.ts
+++ b/src/server/type.ts
@@ -1,0 +1,9 @@
+import { Prisma } from "@prisma/client";
+
+export interface TypedRequest<T> extends Omit<RequestInit, "body" | "method"> {
+  body: T;
+}
+
+export type ChapterWithStudent = Prisma.ChapterGetPayload<{
+  include: { students: true };
+}>;


### PR DESCRIPTION
# Description

Refactor `PATCH /api/user/[uid]/edit-profile` to only be editing the current user's profile and implement API endpoint for an admin to update role.

## Issues

Resolves #71.

## Test

Create a dummy button on an account with `ADMIN` role to edit a user's role.