### PR TITLE
Senior View For Chapter Leader

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -86,7 +86,6 @@ enum Role {
 
 model Senior {
   id          String   @id @default(auto()) @map("_id") @db.ObjectId
-  name        String   @default("")   
   firstname   String
   lastname    String
   location    String

--- a/src/app/api/senior/[id]/route.schema.ts
+++ b/src/app/api/senior/[id]/route.schema.ts
@@ -18,7 +18,6 @@ export const seniorDeleteResponse = z.discriminatedUnion("code", [
 export const patchSeniorSchema = seniorSchema.pick({
   firstname: true,
   lastname: true,
-  name: true, // TODO(nickbar01234) - Remove name
   location: true,
   StudentIDs: true,
   description: true,

--- a/src/app/api/senior/route.schema.ts
+++ b/src/app/api/senior/route.schema.ts
@@ -5,7 +5,6 @@ import { seniorSchema } from "@server/model";
 export const postSeniorSchema = seniorSchema.pick({
   firstname: true,
   lastname: true,
-  name: true, // TODO(nickbar01234) - Remove name
   location: true,
   StudentIDs: true,
   description: true,

--- a/src/app/api/senior/route.ts
+++ b/src/app/api/senior/route.ts
@@ -85,7 +85,6 @@ export const POST = withSessionAndRole(
 
       const senior = await prisma.senior.create({
         data: {
-          name: seniorBody.name,
           firstname: seniorBody.firstname,
           lastname: seniorBody.lastname,
           location: seniorBody.location,

--- a/src/app/private/[uid]/chapter-leader/pending/PendingHomePage.tsx
+++ b/src/app/private/[uid]/chapter-leader/pending/PendingHomePage.tsx
@@ -24,7 +24,7 @@ const PendingHomePage = ({ users }: MembersHomePageProps) => {
         />
       ) : (
         <h1 className="text-2xl font-light">
-          {"This chapter has no members."}
+          {"This chapter has no pending members."}
         </h1>
       )}
     </>

--- a/src/app/private/[uid]/chapter-leader/seniors/[seniorId]/page.tsx
+++ b/src/app/private/[uid]/chapter-leader/seniors/[seniorId]/page.tsx
@@ -1,0 +1,41 @@
+import PathNav from "@components/PathNav";
+import { DisplaySenior } from "@components/senior";
+import { prisma } from "@server/db/client";
+import { seniorFullName } from "@utils";
+
+interface LayoutProps {
+  params: {
+    seniorId: string;
+  };
+}
+
+const Page = async ({ params }: LayoutProps) => {
+  const senior = await prisma.senior.findFirstOrThrow({
+    where: { id: params.seniorId },
+    include: {
+      Files: true,
+      chapter: {
+        include: {
+          students: true,
+        },
+      },
+    },
+  });
+
+  return (
+    <div className="flex flex-col gap-y-6">
+      <PathNav
+        pathInfo={[
+          { display: "Seniors", url: "seniors" },
+          {
+            display: seniorFullName(senior),
+            url: `seniors/${seniorFullName(senior)}`,
+          },
+        ]}
+      />
+      <DisplaySenior editable canAddFile={false} senior={senior} />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/private/[uid]/chapter-leader/seniors/layout.tsx
+++ b/src/app/private/[uid]/chapter-leader/seniors/layout.tsx
@@ -1,0 +1,16 @@
+import { HeaderContainer } from "@components/container";
+import { faUsers } from "@fortawesome/free-solid-svg-icons";
+
+interface LayoutProps {
+  children?: React.ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => {
+  return (
+    <HeaderContainer header="Seniors" showHorizontalLine headerIcon={faUsers}>
+      {children}
+    </HeaderContainer>
+  );
+};
+
+export default Layout;

--- a/src/app/private/[uid]/chapter-leader/seniors/page.tsx
+++ b/src/app/private/[uid]/chapter-leader/seniors/page.tsx
@@ -1,7 +1,5 @@
 import React from "react";
 import { prisma } from "@server/db/client";
-import { faUsers } from "@fortawesome/free-solid-svg-icons";
-import { HeaderContainer } from "@components/container";
 import { SeniorView } from "@components/SeniorView";
 
 const UserSeniorsPage = async ({ params }: { params: { uid: string } }) => {
@@ -29,14 +27,10 @@ const UserSeniorsPage = async ({ params }: { params: { uid: string } }) => {
   const students = chapter?.students ? chapter.students : [];
 
   return (
-    <HeaderContainer
-      header="Seniors"
-      showHorizontalLine={true}
-      headerIcon={faUsers}
-    >
+    <>
       <div className="mb-6 text-2xl">Seniors {`(${seniors.length})`}</div>
       <SeniorView seniors={seniors} students={students} />
-    </HeaderContainer>
+    </>
   );
 };
 

--- a/src/app/private/[uid]/chapter-leader/users/MembersHomePage.tsx
+++ b/src/app/private/[uid]/chapter-leader/users/MembersHomePage.tsx
@@ -27,7 +27,9 @@ const MembersHomePage = ({ members, user }: MembersHomePageProps) => {
         display={displayMembers}
         elements={members}
         emptyNode={
-          <h1 className="text-2xl font-light">This chapter has no members.</h1>
+          <h1 className="text-2xl font-light text-[#000022]">
+            This chapter has no members.
+          </h1>
         }
         search={(member: User, filter: string) =>
           (member.firstName + " " + member.lastName)

--- a/src/app/private/[uid]/chapter-leader/users/[userId]/page.tsx
+++ b/src/app/private/[uid]/chapter-leader/users/[userId]/page.tsx
@@ -1,0 +1,35 @@
+import PathNav from "@components/PathNav";
+import SearchableContainer from "@components/SearchableContainer";
+import { prisma } from "@server/db/client";
+import { fullName } from "@utils";
+
+interface PageProps {
+  params: {
+    userId: string;
+  };
+}
+
+const Page = async ({ params }: PageProps) => {
+  const { userId } = params;
+  const user = await prisma.user.findUniqueOrThrow({
+    where: {
+      id: userId,
+    },
+    include: {
+      Seniors: true,
+    },
+  });
+
+  return (
+    <div className="flex h-full w-full flex-col gap-y-6">
+      <PathNav
+        pathInfo={[
+          { display: "Members", url: "users" },
+          { display: fullName(user), url: `users/${user.id}` },
+        ]}
+      />
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/private/[uid]/user/seniors/SeniorsHomePage.tsx
+++ b/src/app/private/[uid]/user/seniors/SeniorsHomePage.tsx
@@ -3,6 +3,7 @@
 import { UserTile } from "@components/TileGrid";
 import { Senior, User } from "@prisma/client";
 import SearchableContainer from "@components/SearchableContainer";
+import { seniorFullName } from "@utils";
 
 type SeniorsHomePageProps = {
   seniors: Senior[];
@@ -32,7 +33,7 @@ const SeniorsHomePage = ({ seniors, user }: SeniorsHomePageProps) => {
           </h1>
         }
         search={(senior: Senior, filter: string) =>
-          senior.name.toLowerCase().includes(filter.toLowerCase())
+          seniorFullName(senior).toLowerCase().includes(filter.toLowerCase())
         }
       />
     </>

--- a/src/app/private/[uid]/user/seniors/[seniorId]/page.tsx
+++ b/src/app/private/[uid]/user/seniors/[seniorId]/page.tsx
@@ -38,7 +38,7 @@ const Page = async ({ params }: PageProps) => {
           },
         ]}
       />
-      <DisplaySenior editable={false} senior={senior} />
+      <DisplaySenior editable={false} canAddFile senior={senior} />
     </div>
   );
 };

--- a/src/components/AddSenior.tsx
+++ b/src/components/AddSenior.tsx
@@ -93,7 +93,7 @@ const StudentSelector = ({
 
 type SeniorData = Pick<
   z.infer<typeof seniorSchema>,
-  "firstname" | "lastname" | "name" | "location" | "description"
+  "firstname" | "lastname" | "location" | "description"
 >;
 
 const AddSenior = ({
@@ -108,7 +108,6 @@ const AddSenior = ({
   const emptySenior: SeniorData = {
     firstname: "",
     lastname: "",
-    name: "",
     location: "",
     description: "",
   };
@@ -166,7 +165,6 @@ const AddSenior = ({
     // put accumulated students into senior model data
     const seniorModel = {
       ...seniorData,
-      name: `${seniorData.firstname} ${seniorData.lastname}`,
       StudentIDs: selectedStudents.map((usr) => usr.id),
     };
 

--- a/src/components/SeniorView.tsx
+++ b/src/components/SeniorView.tsx
@@ -4,7 +4,8 @@ import { Senior, User } from "@prisma/client";
 import SearchableContainer from "./SearchableContainer";
 import { UserTile } from "./TileGrid";
 import AddSenior from "./AddSenior";
-import { useState } from "react";
+import { useContext, useState } from "react";
+import { UserContext } from "@context/UserProvider";
 
 type SeniorViewProps = {
   seniors: Senior[];
@@ -12,6 +13,7 @@ type SeniorViewProps = {
 };
 
 export const SeniorView = ({ seniors, students }: SeniorViewProps) => {
+  const context = useContext(UserContext);
   const [seniorsState, setSeniorsState] = useState(seniors);
   const [showAddSeniorPopUp, setShowAddSeniorPopUp] = useState(false);
   const [seniorPatch, setSeniorPatch] = useState("");
@@ -32,8 +34,11 @@ export const SeniorView = ({ seniors, students }: SeniorViewProps) => {
       }
       elements={seniorsState ? seniorsState : []}
       display={(senior, index) => (
-        // TODO(nickbar01234) - Fix link
-        <UserTile senior={senior} link="bleh" key={senior.id} />
+        <UserTile
+          senior={senior}
+          link={`/private/${context.user.id}/chapter-leader/seniors/${senior.id}`}
+          key={senior.id}
+        />
       )}
       search={(senior, key) =>
         (senior.firstname + " " + senior.lastname)

--- a/src/components/senior/DisplaySenior.tsx
+++ b/src/components/senior/DisplaySenior.tsx
@@ -5,13 +5,12 @@ import { File as PrismaFile, Prisma } from "@prisma/client";
 import { formatFileDate } from "@utils";
 import { File } from "@components/file";
 import AddFile from "@components/file/AddFile";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { v4 as uuid } from "uuid";
 import Assigment from "./assignment";
 
 interface DisplayProps {
   editable: boolean;
+  canAddFile: boolean;
   senior: Prisma.SeniorGetPayload<{
     include: { Files: true; chapter: { include: { students: true } } };
   }>;
@@ -46,7 +45,7 @@ const FILES: PrismaFile[] = [
 ];
 
 const DisplaySenior = (props: DisplayProps) => {
-  const { editable, senior } = props;
+  const { editable, canAddFile, senior } = props;
   const addFileId = uuid();
 
   return (
@@ -59,7 +58,10 @@ const DisplaySenior = (props: DisplayProps) => {
         display={(file) => <File key={file.id} file={file} />}
         elements={FILES} // TODO(nickbar01234) - Replace with real data
         search={(file, filter) => formatFileDate(file.date).includes(filter)}
-        addElementComponent={<AddFile key={addFileId} />}
+        addElementComponent={canAddFile && <AddFile key={addFileId} />}
+        emptyNode={
+          <p className="text-2xl font-light text-[#000022]">No files yet.</p>
+        }
       />
     </div>
   );

--- a/src/components/senior/assignment/index.tsx
+++ b/src/components/senior/assignment/index.tsx
@@ -39,7 +39,6 @@ const Assignment = (props: AssignmentProps) => {
               body: {
                 firstname: senior.firstname,
                 lastname: senior.lastname,
-                name: senior.name,
                 location: senior.location,
                 description: senior.description,
                 StudentIDs: assigned.map((user) => user.id),

--- a/src/server/model/index.ts
+++ b/src/server/model/index.ts
@@ -5,7 +5,6 @@ export const seniorSchema = z.object({
   id: z.string(),
   firstname: z.string(),
   lastname: z.string(),
-  name: z.string(),
   location: z.string(),
   description: z.string(),
   StudentIDs: z.array(z.string()),

--- a/src/utils/index.tsx
+++ b/src/utils/index.tsx
@@ -1,6 +1,6 @@
 import { RoleToUrlSegment } from "@constants";
 import { Session } from "next-auth";
-import { Resource, User } from "@prisma/client";
+import { Resource, Senior, User } from "@prisma/client";
 import moment from "moment";
 
 export const formatUserHomeRoute = (user: NonNullable<Session["user"]>) => {
@@ -38,3 +38,6 @@ export const formatFileDate = (date: Date) =>
   moment(date).format("MMM DD YYYY");
 
 export const fullName = (user: User) => `${user.firstName} ${user.lastName}`;
+
+export const seniorFullName = (senior: Senior) =>
+  `${senior.firstname} ${senior.lastname}`;


### PR DESCRIPTION
# Description

Display a specific senior's information for a Chapter Leader. Additionally, I did a quick sweep to remove all usage of `name` from `Senior` model as that is deprecated.

## Screenshots

![image](https://github.com/JumboCode/TheLegacyProject2/assets/74647679/331bccd6-2634-4e5b-8674-55b19228aece)

## Test

1. Login an account with role `CHAPTER_LEADER`
2. Navigate to `/private/[uid]/chapter-leader/[seniorId]`
3. Edit student assignment for this senior / Check for mobile responsiveness