### PR TITLE
Update permission model

### DIFF
--- a/.github/workflows/unit-testing.yml
+++ b/.github/workflows/unit-testing.yml
@@ -36,3 +36,5 @@ jobs:
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
           GOOGLE_BASEFOLDER: ${{ secrets.GOOGLE_BASEFOLDER }}
+          GOOGLE_CLIENT_EMAIL: ${{ secrets.GOOGLE_CLIENT_EMAIL }}
+          GOOGLE_PRIVATE_KEY: ${{ secrets.GOOGLE_PRIVATE_KEY }}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,18 +5,7 @@ import { prisma } from "@server/db/client";
 import NextAuth, { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 
-const GOOGLE_API_SCOPE = [
-  "https://www.googleapis.com/auth/drive",
-  "https://www.googleapis.com/auth/drive.appdata",
-  "https://www.googleapis.com/auth/drive.appfolder",
-  "https://www.googleapis.com/auth/drive.file",
-  "https://www.googleapis.com/auth/drive.resource",
-  "https://www.googleapis.com/auth/documents",
-  "https://www.googleapis.com/auth/documents.readonly",
-  "https://www.googleapis.com/auth/userinfo.profile",
-  "https://www.googleapis.com/auth/userinfo.email",
-  "openid",
-];
+const GOOGLE_API_SCOPE = ["openid"];
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -5,7 +5,11 @@ import { prisma } from "@server/db/client";
 import NextAuth, { NextAuthOptions } from "next-auth";
 import GoogleProvider from "next-auth/providers/google";
 
-const GOOGLE_API_SCOPE = ["openid"];
+const GOOGLE_API_SCOPE = [
+  "openid",
+  "https://www.googleapis.com/auth/userinfo.profile",
+  "https://www.googleapis.com/auth/userinfo.email",
+];
 
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),

--- a/src/app/api/file/[fileId]/route.ts
+++ b/src/app/api/file/[fileId]/route.ts
@@ -6,12 +6,10 @@ import { FileResponse } from "./route.schema";
 import { File } from "@server/model";
 import { prisma } from "@server/db/client";
 import { withSession } from "@server/decorator";
-import { createDriveService } from "@server/service";
+import { driveV3 } from "@server/service";
 import moment from "moment";
 
 export const PATCH = withSession(async (request) => {
-  const service = await createDriveService(request.session.user.id);
-
   const body = await request.req.json();
   const nextParams: { fileId: string } = request.params.params;
   const { fileId } = nextParams;
@@ -97,7 +95,7 @@ export const PATCH = withSession(async (request) => {
       resource: body,
     };
 
-    await service.files.update(fileUpdateData);
+    await driveV3.files.update(fileUpdateData);
 
     const file = await prisma.file.findFirst({
       where: {
@@ -131,8 +129,6 @@ export const PATCH = withSession(async (request) => {
 });
 
 export const DELETE = withSession(async (request) => {
-  const service = await createDriveService(request.session.user.id);
-
   const nextParams: { fileId: string } = request.params.params;
   const { fileId } = nextParams;
 
@@ -192,7 +188,7 @@ export const DELETE = withSession(async (request) => {
     );
   }
 
-  await service.files.delete({
+  await driveV3.files.delete({
     fileId: fileId,
   });
 

--- a/src/app/api/handle-chapter-request/route.ts
+++ b/src/app/api/handle-chapter-request/route.ts
@@ -4,11 +4,11 @@ import {
   HandleChapterRequestResponse,
 } from "./route.schema";
 import { withSession } from "@server/decorator";
-import { createDriveService } from "@server/service";
+import { driveV3 } from "@server/service";
 import { env } from "@env/server.mjs";
 import { prisma } from "@server/db/client";
 
-export const POST = withSession(async ({ req, session }) => {
+export const POST = withSession(async ({ req }) => {
   const handleChapterRequest = HandleChapterRequest.safeParse(await req.json());
   if (!handleChapterRequest.success) {
     return NextResponse.json(
@@ -73,8 +73,7 @@ export const POST = withSession(async ({ req, session }) => {
       fields: "id",
     };
 
-    const service = await createDriveService(session.user.id);
-    const file = await service.files.create(fileCreateData);
+    const file = await driveV3.files.create(fileCreateData);
     const googleFolderId = file.data.id as string;
 
     await prisma.chapter.update({

--- a/src/app/api/senior/route.ts
+++ b/src/app/api/senior/route.ts
@@ -2,7 +2,7 @@ import { withSessionAndRole } from "@server/decorator";
 import { NextResponse } from "next/server";
 import { seniorPostResponse, postSeniorSchema } from "./route.schema";
 import { prisma } from "@server/db/client";
-import { createDriveService } from "@server/service";
+import { driveV3 } from "@server/service";
 
 // @TODO - Use google drive service to create folder
 export const POST = withSessionAndRole(
@@ -83,11 +83,7 @@ export const POST = withSessionAndRole(
         fields: "id",
       };
 
-      const service = await createDriveService(session.user.id);
-
-      const file = await (service as NonNullable<typeof service>).files.create(
-        fileCreateData
-      );
+      const file = await driveV3.files.create(fileCreateData);
       const googleFolderId = (file as any).data.id;
 
       await prisma.senior.update({

--- a/src/app/api/user-request/route.ts
+++ b/src/app/api/user-request/route.ts
@@ -7,7 +7,7 @@ import {
 } from "./route.schema";
 import { prisma } from "@server/db/client";
 import { withSession } from "@server/decorator/index";
-import { createDriveService } from "@server/service";
+import { driveV3 } from "@server/service";
 
 export const POST = withSession(async ({ req, session }) => {
   try {
@@ -194,16 +194,15 @@ export const PATCH = withSession(async ({ req, session }) => {
 
   // Next, share the folder with the user that is accepted
   const shareFolder = async (folderId: string, userEmail: string) => {
-    const service = await createDriveService(session.user.id);
     // Define the permission
     const permission = {
       type: "user",
-      role: "writer", // Change role as per your requirement
+      role: "reader", // Change role as per your requirement
       emailAddress: userEmail,
     };
 
     // Share the folder
-    await service.permissions.create({
+    await driveV3.permissions.create({
       fileId: folderId,
       requestBody: permission,
     });

--- a/src/app/private/user/home/page.tsx
+++ b/src/app/private/user/home/page.tsx
@@ -4,36 +4,40 @@ import { getServerSessionOrRedirect } from "@server/utils";
 
 const UserHomePage = async () => {
   const session = await getServerSessionOrRedirect();
-  const chapter = await prisma.chapter.findFirstOrThrow({
-    where: {
-      id: session.user?.ChapterID ?? "",
-    },
-    include: {
-      students: {
-        where: {
-          OR: [
-            {
-              position: {
-                not: "",
+  if (session.user?.ChapterID != null) {
+    const chapter = await prisma.chapter.findFirstOrThrow({
+      where: {
+        id: session.user?.ChapterID ?? "",
+      },
+      include: {
+        students: {
+          where: {
+            OR: [
+              {
+                position: {
+                  not: "",
+                },
               },
-            },
-            {
-              role: "CHAPTER_LEADER",
-            },
-          ],
+              {
+                role: "CHAPTER_LEADER",
+              },
+            ],
+          },
         },
       },
-    },
-  });
-  const resources = await prisma.resource.findMany({
-    where: {
-      access: {
-        isEmpty: true,
+    });
+    const resources = await prisma.resource.findMany({
+      where: {
+        access: {
+          isEmpty: true,
+        },
       },
-    },
-  });
+    });
 
-  return <DisplayChapterInfo chapter={chapter} resources={resources} />;
+    return <DisplayChapterInfo chapter={chapter} resources={resources} />;
+  } else {
+    return null;
+  }
 };
 
 export default UserHomePage;

--- a/src/env/schema.mjs
+++ b/src/env/schema.mjs
@@ -19,6 +19,11 @@ export const serverSchema = z.object({
   GOOGLE_CLIENT_ID: z.string(),
   GOOGLE_CLIENT_SECRET: z.string(),
   GOOGLE_BASEFOLDER: z.string(),
+
+  GOOGLE_CLIENT_EMAIL: z.string().email(),
+  // https://github.com/orgs/vercel/discussions/219
+  // Parsing \n inserts \\n
+  GOOGLE_PRIVATE_KEY: z.string().transform((key) => key.replace(/\\n/g, "\n")),
 });
 
 /**

--- a/src/server/service/index.ts
+++ b/src/server/service/index.ts
@@ -1,38 +1,13 @@
-import { prisma } from "@server/db/client";
 import { google } from "googleapis";
 import { env } from "@env/server.mjs";
 
-export const createDriveService = async (userID: string) => {
-  const account = await prisma.account.findFirst({
-    where: {
-      userId: userID,
+export const driveV3 = google.drive({
+  version: "v3",
+  auth: new google.auth.GoogleAuth({
+    credentials: {
+      client_email: env.GOOGLE_CLIENT_EMAIL,
+      private_key: env.GOOGLE_PRIVATE_KEY,
     },
-  });
-
-  if (
-    account === null ||
-    account.access_token === null ||
-    account.refresh_token === null
-  ) {
-    throw new Error("Invalid google drive authentication");
-  }
-
-  const { access_token, refresh_token } = account;
-
-  const auth = new google.auth.OAuth2({
-    clientId: env.GOOGLE_CLIENT_ID,
-    clientSecret: env.GOOGLE_CLIENT_SECRET,
-  });
-
-  auth.setCredentials({
-    access_token,
-    refresh_token,
-  });
-
-  const service = google.drive({
-    version: "v3",
-    auth,
-  });
-
-  return service;
-};
+    scopes: ["https://www.googleapis.com/auth/drive"],
+  }),
+});


### PR DESCRIPTION
# Description

Migrate Google Drive API to using service account.

Currently, we're asking users for permissions to access their **entire drive** when folders are created on user's behalf to a specific drive owned by us.

This has an additional upside of making our app "safer", since we're not asking for restricted scope.

## Test

Test different routes that interact with Google Drive.

1. `handle-chapter-request`
2. `user-request`
3. `POST seniors`
4. `POST files`

## Additional Documentations

This requires adding 2 more variables to `.env`